### PR TITLE
Add issue and PR automation workflows

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,19 @@
+name: Add issues and PRs to project
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+  pull_request:
+    types:
+      - opened
+      - reopened
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add to DevRel
+        uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/pulumi/projects/47
+          github-token: ${{ secrets.PULUMI_BOT_GHA_MARKETING }}

--- a/.github/workflows/add-triage-label.yml
+++ b/.github/workflows/add-triage-label.yml
@@ -1,0 +1,17 @@
+name: Add triage label to new issues and PRs
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+  pull_request:
+    types:
+      - opened
+      - reopened
+jobs:
+  add-triage-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: needs-triage


### PR DESCRIPTION
Add workflows to automate adding issues and PRs to DevRel team board and labeling with "needs-triage" label

Part of https://github.com/pulumi/devrel-team/issues/518